### PR TITLE
Add proxy and hidden service to liquidd

### DIFF
--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -153,9 +153,10 @@ in {
     ";
     services.liquidd.listen = true;
     services.liquidd.proxy = config.services.tor.client.socksListenAddress;
+    services.liquidd.port = 7042;
     services.tor.hiddenServices.liquidd = {
       map = [{
-        port = 7042; toPort = 7042;
+        port = config.services.liquidd.port; toPort = config.services.liquidd.port;
       }];
       version = 3;
     };

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -151,7 +151,15 @@ in {
       mainchainrpcuser=${config.services.bitcoind.rpcuser}
       mainchainrpcport=8332
     ";
-
+    services.liquidd.listen = true;
+    services.liquidd.proxy = config.services.tor.client.socksListenAddress;
+    services.tor.hiddenServices.liquidd = {
+      map = [{
+        port = 7042; toPort = 7042;
+      }];
+      version = 3;
+    };
+     
     services.lightning-charge.enable = cfg.modules == "all";
     services.nanopos.enable = cfg.modules == "all";
     services.nix-bitcoin-webindex.enable = cfg.modules == "all";

--- a/pkgs/nodeinfo.sh
+++ b/pkgs/nodeinfo.sh
@@ -17,6 +17,12 @@ if [ -e "$NGINX_ONION_FILE" ]; then
     echo NGINX_ONION="$NGINX_ONION"
 fi
 
+LIQUIDD_ONION_FILE=/var/lib/tor/onion/liquidd/hostname
+if [ -e "$LIQUIDD_ONION_FILE" ]; then
+    LIQUIDD_ONION="$(cat $LIQUIDD_ONION_FILE)"
+    echo LIQUIDD_ONION="$LIQUIDD_ONION"
+fi
+
 SPARKWALLET_ONION_FILE=/var/lib/tor/onion/spark-wallet/hostname
 if [ -e "$SPARKWALLET_ONION_FILE" ]; then
     SPARKWALLET_ONION="$(cat $SPARKWALLET_ONION_FILE)"


### PR DESCRIPTION
This commit adds Tor support to liquidd. Should it include the external ip option to advertise the hidden service for inbound connections?