### PR TITLE
Fix electrs and add electrs hidden service

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -9,9 +9,8 @@ let
     ${optionalString cfg.testnet "testnet=1"}
     ${optionalString (cfg.dbCache != null) "dbcache=${toString cfg.dbCache}"}
     ${optionalString (cfg.prune != null) "prune=${toString cfg.prune}"}
-    sysperms=${if cfg.sysperms then "1" else "0"}
-    disablewallet=${if cfg.disablewallet then "1" else "0"}
-
+    ${optionalString (cfg.sysperms != null) "sysperms=${if cfg.sysperms then "1" else "0"}"}
+    ${optionalString (cfg.disablewallet != null) "disablewallet=${if cfg.disablewallet then "1" else "0"}"}
 
     # Connection options
     ${optionalString (cfg.port != null) "port=${toString cfg.port}"}
@@ -155,19 +154,17 @@ in {
         '';
       };
       sysperms = mkOption {
-        type = types.bool;
-        default = false;
+        type = types.nullOr types.bool;
+        default = null;
         description = ''
         Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)
-        # Necessary for electrs
         '';
       };
       disablewallet = mkOption {
-        type = types.bool;
-        default = false;
+        type = types.nullOr types.bool;
+        default = null;
         description = ''
         Do not load the wallet and disable wallet RPC calls
-        # Necessary for electrs
         '';
       };
       dbCache = mkOption {

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -9,6 +9,9 @@ let
     ${optionalString cfg.testnet "testnet=1"}
     ${optionalString (cfg.dbCache != null) "dbcache=${toString cfg.dbCache}"}
     ${optionalString (cfg.prune != null) "prune=${toString cfg.prune}"}
+    sysperms=${if cfg.sysperms then "1" else "0"}
+    disablewallet=${if cfg.disablewallet then "1" else "0"}
+
 
     # Connection options
     ${optionalString (cfg.port != null) "port=${toString cfg.port}"}
@@ -151,6 +154,22 @@ in {
           If enabled, the bitcoin service will listen.
         '';
       };
+      sysperms = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+        Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)
+        # Necessary for electrs
+        '';
+      };
+      disablewallet = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+        Do not load the wallet and disable wallet RPC calls
+        # Necessary for electrs
+        '';
+      };
       dbCache = mkOption {
         type = types.nullOr (types.ints.between 4 16384);
         default = null;
@@ -195,6 +214,7 @@ in {
         chmod o-rw  '${cfg.dataDir}/bitcoin.conf'
         chown '${cfg.user}:${cfg.group}' '${cfg.dataDir}/bitcoin.conf'
         echo "rpcpassword=$(cat /secrets/bitcoin-rpcpassword)" >> '${cfg.dataDir}/bitcoin.conf'
+        chmod -R g+rX '${cfg.dataDir}/blocks'
       '';
       serviceConfig = {
         Type = "simple";

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -24,7 +24,7 @@ in {
       type = types.bool;
       default = false;
       description = ''
-      If enabled, the electrs service will sync faster on high-memory systems.
+      If enabled, the electrs service will sync faster on high-memory systems (≤ 8GB).
       '';
     };
   };

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -78,8 +78,8 @@ in {
     # bitcoind
     services.bitcoind.enable = true;
     services.bitcoind.listen = true;
-    services.bitcoind.sysperms = true;
-    services.bitcoind.disablewallet = true;
+    services.bitcoind.sysperms = if config.services.electrs.enable then true else null;
+    services.bitcoind.disablewallet = if config.services.electrs.enable then true else null;
     services.bitcoind.proxy = config.services.tor.client.socksListenAddress;
     services.bitcoind.port = 8333;
     services.bitcoind.rpcuser = "bitcoinrpc";
@@ -164,7 +164,7 @@ in {
       }];
       version = 3;
     };
-    services.electrs.enable = true;
+    services.electrs.enable = cfg.modules == "all";
     services.electrs.high-memory = false;
     services.tor.hiddenServices.electrs = {
       map = [{

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -16,8 +16,7 @@ let
     lightning-charge.package
     nanopos.package
     spark-wallet.package
-    # TODO: re-enable when fixed
-    #electrs
+    electrs
     nodejs-8_x
     nginx
   ];
@@ -79,6 +78,8 @@ in {
     # bitcoind
     services.bitcoind.enable = true;
     services.bitcoind.listen = true;
+    services.bitcoind.sysperms = true;
+    services.bitcoind.disablewallet = true;
     services.bitcoind.proxy = config.services.tor.client.socksListenAddress;
     services.bitcoind.port = 8333;
     services.bitcoind.rpcuser = "bitcoinrpc";
@@ -157,11 +158,17 @@ in {
     services.nix-bitcoin-webindex.enable = cfg.modules == "all";
     services.clightning.autolisten = cfg.modules == "all";
     services.spark-wallet.enable = cfg.modules == "all";
-    # TODO: re-enable when fixed
-    services.electrs.enable = false;
     services.tor.hiddenServices.spark-wallet = {
       map = [{
         port = 80; toPort = 9737;
+      }];
+      version = 3;
+    };
+    services.electrs.enable = true;
+    services.electrs.high-memory = false;
+    services.tor.hiddenServices.electrs = {
+      map = [{
+        port = 50001; toPort = 50001;
       }];
       version = 3;
     };

--- a/pkgs/electrs.nix
+++ b/pkgs/electrs.nix
@@ -2,11 +2,11 @@ let
   overlay = builtins.fetchGit {
      url = "https://github.com/mozilla/nixpkgs-mozilla";
      ref = "master";
-     rev = "f61795ea78ea2a489a2cabb27abde254d2a37d25";
+     rev = "e37160aaf4de5c4968378e7ce6fe5212f4be239f";
    };
   defaultPkgs = import <nixpkgs> {overlays = [ (import overlay) ]; };
-  defaultRust = defaultPkgs.latest.rustChannels.nightly.rust;
-  defaultCargo = defaultPkgs.latest.rustChannels.nightly.cargo;
+  defaultRust = (defaultPkgs.rustChannelOf { date = "2019-03-05"; channel = "nightly"; }).rust;
+  defaultCargo = (defaultPkgs.rustChannelOf { date = "2019-03-05"; channel = "nightly"; }).cargo;
   defaultBuildRustPackage = defaultPkgs.callPackage (import <nixpkgs/pkgs/build-support/rust>) {
     rust = {
       rustc = defaultRust;
@@ -19,7 +19,7 @@ pkgs.lib.flip pkgs.callPackage { inherit buildRustPackage; } (
   { lib, buildRustPackage, fetchFromGitHub, llvmPackages, clang }:
 
   let
-    version = "0.4.2";
+    version = "0.4.3";
 
   in buildRustPackage {
     name = "electrs-${version}";
@@ -27,11 +27,11 @@ pkgs.lib.flip pkgs.callPackage { inherit buildRustPackage; } (
     src = fetchFromGitHub {
       owner = "romanz";
       repo = "electrs";
-      rev = "5f2d4289dcb98ef283725b3d12f8733a7b9e832b";
-      sha256 = "1lqhrcyd8hdaja5k01a2banvjcbxxcwvb2p7zh05984fpzzs02gr";
+      rev = "5ab3b4648769bf4a421d48fb29c93ef048db7dbf";
+      sha256 = "1xjjs1j4wm8pv7h0gr7i8xi2j78ss3haai4hyaiavwph8kk5n0ch";
     };
 
-    cargoSha256 = "0v0cc62mx728cqfyz3x1bfh2436yiw2hkv58672j2f45cafcgp2h";
+    cargoSha256 = "0a80i77s3r4nivrrxndadzgxcpnyamrw7xqrrlz1ylwyjz00xcnf";
 
     LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
     buildInputs = [ clang ];
@@ -44,5 +44,3 @@ pkgs.lib.flip pkgs.callPackage { inherit buildRustPackage; } (
     };
   }
 )
-
-

--- a/pkgs/nodeinfo.sh
+++ b/pkgs/nodeinfo.sh
@@ -23,6 +23,12 @@ if [ -e "$SPARKWALLET_ONION_FILE" ]; then
     echo SPARKWALLET_ONION="http://$SPARKWALLET_ONION"
 fi
 
+ELECTRS_ONION_FILE=/var/lib/tor/onion/electrs/hostname
+if [ -e "$ELECTRS_ONION_FILE" ]; then
+    ELECTRS_ONION="$(cat $ELECTRS_ONION_FILE)"
+    echo ELECTRS_ONION="$ELECTRS_ONION"
+fi
+
 SSHD_ONION_FILE=/var/lib/tor/onion/sshd/hostname
 if [ -e "$SSHD_ONION_FILE" ]; then
     SSHD_ONION="$(cat $SSHD_ONION_FILE)"


### PR DESCRIPTION
This commit fixes electrs, reenables it, adds an electrs Tor v3 HS so users can connect from the outside, and a high-memory option. 

The high-memory option allows users with high-memory (< 8 GB RAM) to sync faster. How should this be documented?