### PR TITLE
Use rust stableinstead of nightly, update electrs, specify electrum-rpc-addr

### DIFF
--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -27,6 +27,11 @@ in {
       If enabled, the electrs service will sync faster on high-memory systems (≥ 8GB).
       '';
     };
+    port = mkOption {
+        type = types.ints.u16;
+        default = 50001;
+        description = "Override the default port on which to listen for connections.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -49,7 +54,7 @@ in {
       preStart = ''
         mkdir -m 0770 -p ${cfg.dataDir}
         chown 'electrs:electrs' ${cfg.dataDir}
-        echo "${pkgs.electrs}/bin/electrs -vvv ${index-batch-size} ${jsonrpc-import} --timestamp --db-dir ${cfg.dataDir} --daemon-dir /var/lib/bitcoind --cookie=${config.services.bitcoind.rpcuser}:$(cat /secrets/bitcoin-rpcpassword)" > /var/lib/electrs/startscript.sh
+        echo "${pkgs.electrs}/bin/electrs -vvv ${index-batch-size} ${jsonrpc-import} --timestamp --db-dir ${cfg.dataDir} --daemon-dir /var/lib/bitcoind --cookie=${config.services.bitcoind.rpcuser}:$(cat /secrets/bitcoin-rpcpassword) --electrum-rpc-addr=127.0.0.1:${toString cfg.port}" > /var/lib/electrs/startscript.sh
         chown -R 'electrs:electrs' ${cfg.dataDir}
         chmod u+x ${cfg.dataDir}/startscript.sh
         '';	

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -17,7 +17,6 @@ let
     lightning-charge
     nanopos
     spark-wallet
-    electrs
     nodejs-8_x
     nginx
   ];
@@ -175,10 +174,11 @@ in {
       version = 3;
     };
     services.electrs.enable = false;
+    services.electrs.port = 50001;
     services.electrs.high-memory = false;
     services.tor.hiddenServices.electrs = {
       map = [{
-        port = 50001; toPort = 50001;
+        port = config.services.electrs.port; toPort = config.services.electrs.port;
       }];
       version = 3;
     };

--- a/pkgs/electrs/default.nix
+++ b/pkgs/electrs/default.nix
@@ -1,37 +1,18 @@
-let
-  overlay = builtins.fetchGit {
-     url = "https://github.com/mozilla/nixpkgs-mozilla";
-     ref = "master";
-     rev = "e37160aaf4de5c4968378e7ce6fe5212f4be239f";
-   };
-  defaultPkgs = import <nixpkgs> {overlays = [ (import overlay) ]; };
-  defaultRust = (defaultPkgs.rustChannelOf { date = "2019-03-05"; channel = "nightly"; }).rust;
-  defaultCargo = (defaultPkgs.rustChannelOf { date = "2019-03-05"; channel = "nightly"; }).cargo;
-  defaultBuildRustPackage = defaultPkgs.callPackage (import <nixpkgs/pkgs/build-support/rust>) {
-    rust = {
-      rustc = defaultRust;
-      cargo = defaultCargo;
-    };
-  };
+{ pkgs }:
 
-in { pkgs ? defaultPkgs, rust ? defaultRust, buildRustPackage ? defaultBuildRustPackage }:
-pkgs.lib.flip pkgs.callPackage { inherit buildRustPackage; } (
-  { lib, buildRustPackage, fetchFromGitHub, llvmPackages, clang }:
-
-  let
-    version = "0.4.3";
-
-  in buildRustPackage {
+with pkgs;
+rustPlatform_1_31.buildRustPackage rec {
     name = "electrs-${version}";
+    version = "0.5.0";    
 
     src = fetchFromGitHub {
       owner = "romanz";
       repo = "electrs";
-      rev = "5ab3b4648769bf4a421d48fb29c93ef048db7dbf";
-      sha256 = "1xjjs1j4wm8pv7h0gr7i8xi2j78ss3haai4hyaiavwph8kk5n0ch";
+      rev = "b2b7e1c42acc306df46e97f39d9ab19d2f6f24a8";
+      sha256 = "1nz75vc170r6q2hbkyil818y6szrjsas1drxj9vyqls7n5w6whz1";
     };
 
-    cargoSha256 = "0a80i77s3r4nivrrxndadzgxcpnyamrw7xqrrlz1ylwyjz00xcnf";
+    cargoSha256 = "1rvhgda4mbwpya8snjqh1z7fjzbabkmh44r4g9ibn83wbd4j32mi";
 
     LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
     buildInputs = [ clang ];
@@ -43,4 +24,4 @@ pkgs.lib.flip pkgs.callPackage { inherit buildRustPackage; } (
       platforms = platforms.all;
     };
   }
-)
+


### PR DESCRIPTION
@romanz has enabled rust stable upstream. This commit transitions electrs from rust nightly to rust stable 1.31. It also updates the electrs version to 0.5.0. I also specified the electrum-rpc-addr to make the hidden service at port 50001 more reliable.