### PR TITLE
Remove profiles and replace with options to enable/disable each module separately in configuration.nix

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -11,9 +11,25 @@
     # This is not needed when deploying to a virtual box.
     #./hardware-configuration.nix
   ];
-  services.nix-bitcoin.enable = true;
-  # FIXME Install and use minimal or all modules
-  services.nix-bitcoin.modules = "all";
+  # FIXME Enable modules by uncommenting their respective line. Disable modules by commenting out their respective line.
+    # Enable this module to use the nix-bitcoin node configuration. Only disable this if you know what you are doing.
+    services.nix-bitcoin.enable = true;
+    # Enable this module to use clightning, a Lightning Network implementation in C.
+    services.clightning.enable = true;
+    # Enable this module to use lightning-charge, a simple drop-in solution for accepting lightning payments.
+    # services.lightning-charge.enable = true;
+    # Enable this module to use nanopos, a simple Lightning point-of-sale system, powered by Lightning Charge. Only enable this if lightning-charge is enabled.
+    # services.nanopos.enable = true;
+    # Enable this module to use the nix-bitcoin-webindex, a simple website displaying your node information and link to nanopos store. Only enable this if nanopos is enabled.
+    # services.nix-bitcoin-webindex.enable = true;
+    # Enable this option to listen for incoming connections. By default nix-bitcoin nodes offer outgoing connectivity. 
+    # services.clightning.autolisten = true;
+    # Enable this module to use liquidd, a daemon for an inter-exchange settlement network linking together cryptocurrency exchanges and institutions around the world.
+    # services.liquidd.enable = true;
+    # Enable this module to use spark-wallet, a minimalistic wallet GUI for c-lightning, accessible over the web or through mobile and desktop apps.
+    # services.spark-wallet.enable = true;
+    # Enable this module to use electrs, an efficient re-implementation of Electrum Server in Rust.
+    # services.electrs.enable = true;
 
   # FIXME: Define your hostname.
   networking.hostName = "nix-bitcoin";

--- a/configuration.nix
+++ b/configuration.nix
@@ -13,34 +13,48 @@
   # use the nix-bitcoin node configuration. Only disable this if you know what
   # you are doing.
   services.nix-bitcoin.enable = true;
+
+  ### CLIGHTNING
   # Enable this module to use clightning, a Lightning Network implementation
   # in C.
   services.clightning.enable = true;
-  # Enable this module to use lightning-charge, a simple drop-in solution for
-  # accepting lightning payments. Only enable this if clightning is enabled.
-  # services.lightning-charge.enable = true; 
-  # Enable this module to use nanopos, a simple Lightning point-of-sale
-  # system, powered by Lightning Charge. Only enable this if clightning and
-  # lightning-charge are enabled.
-  # services.nanopos.enable = true; 
-  # Enable this module to use the nix-bitcoin-webindex, a simple website
-  # displaying your node information and link to nanopos store. Only enable
-  # this if clightning, lightning-charge, and nanopos are enabled.
-  # services.nix-bitcoin-webindex.enable = true; 
   # Enable this option to listen for incoming lightning connections. By
-  # default nix-bitcoin nodes offer outgoing connectivity.  
-  # services.clightning.autolisten = true; 
-  # Enable this module to use liquidd, a daemon for an inter-exchange
-  # settlement network linking together cryptocurrency exchanges and
-  # institutions around the world.  
-  # services.liquidd.enable = true; 
+  # default nix-bitcoin nodes offer outgoing connectivity.
+  # services.clightning.autolisten = true;
+
+  ### SPARK WALLET
   # Enable this module to use spark-wallet, a minimalistic wallet GUI for
   # c-lightning, accessible over the web or through mobile and desktop apps.
-  # Only enable this if clightning is enabled.  
-  # services.spark-wallet.enable = true; 
+  # Only enable this if clightning is enabled.
+  # services.spark-wallet.enable = true;
+
+  ### ELECTRS
   # Enable this module to use electrs, an efficient re-implementation of
   # Electrum Server in Rust.
   # services.electrs.enable = true;
+
+  ### LIQUIDD
+  # Enable this module to use liquidd, a daemon for an inter-exchange
+  # settlement network linking together cryptocurrency exchanges and
+  # institutions around the world.
+  # services.liquidd.enable = true;
+
+  ### LIGHTNING CHARGE
+  # Enable this module to use lightning-charge, a simple drop-in solution for
+  # accepting lightning payments. Only enable this if clightning is enabled.
+  # services.lightning-charge.enable = true;
+
+  ### NANOPOS
+  # Enable this module to use nanopos, a simple Lightning point-of-sale
+  # system, powered by Lightning Charge. Only enable this if clightning and
+  # lightning-charge are enabled.
+  # services.nanopos.enable = true;
+
+  ### WEBINDEX
+  # Enable this module to use the nix-bitcoin-webindex, a simple website
+  # displaying your node information and link to nanopos store. Only enable
+  # this if clightning, lightning-charge, and nanopos are enabled.
+  # services.nix-bitcoin-webindex.enable = true;
 
   # FIXME: Define your hostname.
   networking.hostName = "nix-bitcoin";

--- a/configuration.nix
+++ b/configuration.nix
@@ -2,34 +2,45 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ config, pkgs, ... }:
-{
-  imports = [
-    ./modules/nix-bitcoin.nix
+{ config, pkgs, ... }: { imports = [ ./modules/nix-bitcoin.nix
     # FIXME: Uncomment next line to import your hardware configuration. If so,
     # add the hardware configuration file to the same directory as this file.
     # This is not needed when deploying to a virtual box.
     #./hardware-configuration.nix
   ];
-  # FIXME Enable modules by uncommenting their respective line. Disable modules by commenting out their respective line.
-    # Enable this module to use the nix-bitcoin node configuration. Only disable this if you know what you are doing.
-    services.nix-bitcoin.enable = true;
-    # Enable this module to use clightning, a Lightning Network implementation in C.
-    services.clightning.enable = true;
-    # Enable this module to use lightning-charge, a simple drop-in solution for accepting lightning payments. Only enable this if clightning is enabled.
-    # services.lightning-charge.enable = true;
-    # Enable this module to use nanopos, a simple Lightning point-of-sale system, powered by Lightning Charge. Only enable this if clightning and lightning-charge are enabled.
-    # services.nanopos.enable = true;
-    # Enable this module to use the nix-bitcoin-webindex, a simple website displaying your node information and link to nanopos store. Only enable this if clightning, lightning-charge, and nanopos are enabled.
-    # services.nix-bitcoin-webindex.enable = true;
-    # Enable this option to listen for incoming lightning connections. By default nix-bitcoin nodes offer outgoing connectivity. 
-    # services.clightning.autolisten = true;
-    # Enable this module to use liquidd, a daemon for an inter-exchange settlement network linking together cryptocurrency exchanges and institutions around the world.
-    # services.liquidd.enable = true;
-    # Enable this module to use spark-wallet, a minimalistic wallet GUI for c-lightning, accessible over the web or through mobile and desktop apps. Only enable this if clightning is enabled.
-    # services.spark-wallet.enable = true;
-    # Enable this module to use electrs, an efficient re-implementation of Electrum Server in Rust.
-    # services.electrs.enable = true;
+  # FIXME: Enable modules by uncommenting their respective line. Disable
+  # modules by commenting out their respective line.  Enable this module to
+  # use the nix-bitcoin node configuration. Only disable this if you know what
+  # you are doing.
+  services.nix-bitcoin.enable = true;
+  # Enable this module to use clightning, a Lightning Network implementation
+  # in C.
+  services.clightning.enable = true;
+  # Enable this module to use lightning-charge, a simple drop-in solution for
+  # accepting lightning payments. Only enable this if clightning is enabled.
+  # services.lightning-charge.enable = true; 
+  # Enable this module to use nanopos, a simple Lightning point-of-sale
+  # system, powered by Lightning Charge. Only enable this if clightning and
+  # lightning-charge are enabled.
+  # services.nanopos.enable = true; 
+  # Enable this module to use the nix-bitcoin-webindex, a simple website
+  # displaying your node information and link to nanopos store. Only enable
+  # this if clightning, lightning-charge, and nanopos are enabled.
+  # services.nix-bitcoin-webindex.enable = true; 
+  # Enable this option to listen for incoming lightning connections. By
+  # default nix-bitcoin nodes offer outgoing connectivity.  
+  # services.clightning.autolisten = true; 
+  # Enable this module to use liquidd, a daemon for an inter-exchange
+  # settlement network linking together cryptocurrency exchanges and
+  # institutions around the world.  
+  # services.liquidd.enable = true; 
+  # Enable this module to use spark-wallet, a minimalistic wallet GUI for
+  # c-lightning, accessible over the web or through mobile and desktop apps.
+  # Only enable this if clightning is enabled.  
+  # services.spark-wallet.enable = true; 
+  # Enable this module to use electrs, an efficient re-implementation of
+  # Electrum Server in Rust.
+  # services.electrs.enable = true;
 
   # FIXME: Define your hostname.
   networking.hostName = "nix-bitcoin";

--- a/configuration.nix
+++ b/configuration.nix
@@ -16,17 +16,17 @@
     services.nix-bitcoin.enable = true;
     # Enable this module to use clightning, a Lightning Network implementation in C.
     services.clightning.enable = true;
-    # Enable this module to use lightning-charge, a simple drop-in solution for accepting lightning payments.
+    # Enable this module to use lightning-charge, a simple drop-in solution for accepting lightning payments. Only enable this if clightning is enabled.
     # services.lightning-charge.enable = true;
-    # Enable this module to use nanopos, a simple Lightning point-of-sale system, powered by Lightning Charge. Only enable this if lightning-charge is enabled.
+    # Enable this module to use nanopos, a simple Lightning point-of-sale system, powered by Lightning Charge. Only enable this if clightning and lightning-charge are enabled.
     # services.nanopos.enable = true;
-    # Enable this module to use the nix-bitcoin-webindex, a simple website displaying your node information and link to nanopos store. Only enable this if nanopos is enabled.
+    # Enable this module to use the nix-bitcoin-webindex, a simple website displaying your node information and link to nanopos store. Only enable this if clightning, lightning-charge, and nanopos are enabled.
     # services.nix-bitcoin-webindex.enable = true;
-    # Enable this option to listen for incoming connections. By default nix-bitcoin nodes offer outgoing connectivity. 
+    # Enable this option to listen for incoming lightning connections. By default nix-bitcoin nodes offer outgoing connectivity. 
     # services.clightning.autolisten = true;
     # Enable this module to use liquidd, a daemon for an inter-exchange settlement network linking together cryptocurrency exchanges and institutions around the world.
     # services.liquidd.enable = true;
-    # Enable this module to use spark-wallet, a minimalistic wallet GUI for c-lightning, accessible over the web or through mobile and desktop apps.
+    # Enable this module to use spark-wallet, a minimalistic wallet GUI for c-lightning, accessible over the web or through mobile and desktop apps. Only enable this if clightning is enabled.
     # services.spark-wallet.enable = true;
     # Enable this module to use electrs, an efficient re-implementation of Electrum Server in Rust.
     # services.electrs.enable = true;

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -4,23 +4,7 @@ with lib;
 
 let
   cfg = config.services.nix-bitcoin;
-  minimalPackages = with pkgs; [
-    tor
-    bitcoin
-    clightning
-    nodeinfo
-    banlist
-    jq
-  ];
-  allPackages = with pkgs; [
-    liquidd
-    lightning-charge
-    nanopos
-    spark-wallet
-    nodejs-8_x
-    nginx
-  ];
-  operatorCopySSH = pkgs.writeText "operator-copy-ssh.sh" ''
+  operatorCopySSH = pkgs.writeText "operator-copy-ssh.sh" '' 
     mkdir -p ${config.users.users.operator.home}/.ssh
     if [ -e "${config.users.users.root.home}/.vbox-nixops-client-key" ]; then
       cp ${config.users.users.root.home}/.vbox-nixops-client-key ${config.users.users.operator.home}/.ssh/authorized_keys
@@ -48,13 +32,6 @@ in {
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
-        If enabled, the nix-bitcoin service will be installed.
-      '';
-    };
-    modules = mkOption {
-      type = types.enum [ "minimal" "all" ];
-      default = "minimal";
       description = ''
         If enabled, the nix-bitcoin service will be installed.
       '';
@@ -102,10 +79,7 @@ in {
     users.groups.bitcoinrpc = {};
 
     # clightning
-    services.clightning = {
-      enable = true;
-      bitcoin-rpcuser = config.services.bitcoind.rpcuser;
-    };
+    services.clightning.bitcoin-rpcuser = config.services.bitcoind.rpcuser;
     services.clightning.proxy = config.services.tor.client.socksListenAddress;
     services.clightning.always-use-proxy = true;
     services.clightning.bind-addr = "127.0.0.1:9735";
@@ -149,7 +123,6 @@ in {
       };
     };
 
-    services.liquidd.enable = cfg.modules == "all";
     services.liquidd.rpcuser = "liquidrpc";
     services.liquidd.prune = 1000;
     services.liquidd.extraConfig = "
@@ -166,13 +139,7 @@ in {
       version = 3;
     };
      
-    services.lightning-charge.enable = cfg.modules == "all";
-    services.nanopos.enable = cfg.modules == "all";
-    services.nix-bitcoin-webindex.enable = cfg.modules == "all";
-    services.clightning.autolisten = cfg.modules == "all";
-    services.spark-wallet.enable = cfg.modules == "all";
     services.spark-wallet.onion-service = true;
-    services.electrs.enable = false;
     services.electrs.port = 50001;
     services.electrs.high-memory = false;
     services.tor.hiddenServices.electrs = {
@@ -181,7 +148,20 @@ in {
       }];
       version = 3;
     };
-    environment.systemPackages = if (cfg.modules == "all") then (minimalPackages ++ allPackages) else minimalPackages;
+    environment.systemPackages = with pkgs; [
+      tor
+      bitcoin
+      nodeinfo
+      banlist
+      jq
+    ]
+    ++ optionals config.services.clightning.enable [clightning]
+    ++ optionals config.services.lightning-charge.enable [lightning-charge]
+    ++ optionals config.services.nanopos.enable [nanopos]
+    ++ optionals config.services.nix-bitcoin-webindex.enable [nginx]
+    ++ optionals config.services.liquidd.enable [liquidd]
+    ++ optionals config.services.spark-wallet.enable [spark-wallet]
+    ++ optionals config.services.electrs.enable [electrs];
   };
 }
 


### PR DESCRIPTION
This PR seeks to give the user more granular control over which modules he wants to run on his nix-bitcoin node. Above each option the user will find documentation explaining what the module is and when to enable/disable it.

Tested on top of 1efe510 and f0b78ee 